### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   db:
     container_name: pollz_db
@@ -15,6 +17,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+
   web:
     container_name: pollz_web
     build: .
@@ -23,6 +26,8 @@ services:
     restart: always
     env_file:
       - .env
+    environment:
+      - DJANGO_ENV=development   # <-- added for dev hot-reload
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
I updated the docker-compose.yml and entrypoint.sh so that our Django supports auto-reload in development while still using Gunicorn in production. added an environment variable DJANGO_ENV=development in the web service of docker-compose.yml. modified entrypoint.sh to run python manage.py runserver in development and keep gunicorn for production.