### PR TITLE
Google auth simple fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,5 +14,8 @@ RAZORPAY_KEY_ID=your-razorpay-key-id
 RAZORPAY_KEY_SECRET=your-razorpay-key-secret
 RAZORPAY_WEBHOOK_SECRET=your-razorpay-webhook-secret
 
+# Google oAuth
+REACT_APP_GOOGLE_CLIENT_ID=your-oauth-client-secret
+ALLOWED_EMAIL_DOMAIN=allowed-email-domains
 # Server Configuration (optional)
 # SERVER=False  # Set to True for production

--- a/main/views.py
+++ b/main/views.py
@@ -69,7 +69,17 @@ def google_login(request):
             id_info = id_token.verify_oauth2_token(token, google_requests.Request(), settings.GOOGLE_CLIENT_ID)
         except ValueError as e:
             return Response({"error": "Token not verified with Google"}, status=status.HTTP_400_BAD_REQUEST)
-            
+
+        allowed_domain = "pilani.bits-pilani.ac.in"
+        
+        # Check the 'hd' (hosted domain) claim
+        hosted_domain = id_info.get("hd")
+
+        if hosted_domain != allowed_domain:
+            return Response({
+                "error": "Access denied. Only BITS Pilani accounts are allowed."
+            }, status=status.HTTP_403_FORBIDDEN)
+         
         # Extract user profile information directly from the validated token's payload
         email = id_info.get("email")
         first_name = id_info.get("given_name", "")
@@ -77,7 +87,7 @@ def google_login(request):
         
         if not email:
             return Response({"error": "Email not found in token"}, status=status.HTTP_400_BAD_REQUEST)
-            
+        
         # Check if user exists
         try:
             user = User.objects.get(email=email)

--- a/main/views.py
+++ b/main/views.py
@@ -70,20 +70,18 @@ def google_login(request):
         except ValueError as e:
             return Response({"error": "Token not verified with Google"}, status=status.HTTP_400_BAD_REQUEST)
 
+        email = id_info.get("email")
+        first_name = id_info.get("given_name", "")
+        last_name = id_info.get("family_name", "")
+        
         allowed_domain = settings.ALLOWED_EMAIL_DOMAIN
         
-        # Check the 'hd' (hosted domain) claim
-        hosted_domain = id_info.get("hd")
-
-        if hosted_domain != allowed_domain:
+        if email.split("@")[-1] != allowed_domain: 
             return Response({
                 "error": "Access denied. Only BITS Pilani accounts are allowed."
             }, status=status.HTTP_403_FORBIDDEN)
          
         # Extract user profile information directly from the validated token's payload
-        email = id_info.get("email")
-        first_name = id_info.get("given_name", "")
-        last_name = id_info.get("family_name", "")
         
         if not email:
             return Response({"error": "Email not found in token"}, status=status.HTTP_400_BAD_REQUEST)

--- a/main/views.py
+++ b/main/views.py
@@ -70,7 +70,7 @@ def google_login(request):
         except ValueError as e:
             return Response({"error": "Token not verified with Google"}, status=status.HTTP_400_BAD_REQUEST)
 
-        allowed_domain = "pilani.bits-pilani.ac.in"
+        allowed_domain = settings.ALLOWED_EMAIL_DOMAIN
         
         # Check the 'hd' (hosted domain) claim
         hosted_domain = id_info.get("hd")

--- a/pollz/settings.py
+++ b/pollz/settings.py
@@ -191,3 +191,4 @@ GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")  # Personal Access Token for GitHub API
 
 # Google OAuth Client ID
 GOOGLE_CLIENT_ID = os.getenv("REACT_APP_GOOGLE_CLIENT_ID")
+ALLOWED_EMAIL_DOMAIN = os.getenv("ALLOWED_EMAIL_DOMAIN")

--- a/pollz/settings.py
+++ b/pollz/settings.py
@@ -191,4 +191,4 @@ GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")  # Personal Access Token for GitHub API
 
 # Google OAuth Client ID
 GOOGLE_CLIENT_ID = os.getenv("REACT_APP_GOOGLE_CLIENT_ID")
-ALLOWED_EMAIL_DOMAIN = os.getenv("ALLOWED_EMAIL_DOMAIN")
+ALLOWED_EMAIL_DOMAIN = os.getenv("ALLOWED_EMAIL_DOMAIN", "pilani.bits-pilani.ac.in")


### PR DESCRIPTION

This pull request introduces Google OAuth login support and restricts access to users from a specific email domain. The changes include updating environment configuration, backend settings, and the login logic to enforce domain-based access control.

**Google OAuth integration and domain restriction:**

* Added `REACT_APP_GOOGLE_CLIENT_ID` and `ALLOWED_EMAIL_DOMAIN` to `.env.example` for configuring Google OAuth and allowed email domains.
* Updated `pollz/settings.py` to read `ALLOWED_EMAIL_DOMAIN` from environment variables, defaulting to "pilani.bits-pilani.ac.in".
* Modified the `google_login` view in `main/views.py` to check the user's email domain against `ALLOWED_EMAIL_DOMAIN` and deny access if it does not match, returning a 403 status.